### PR TITLE
Feature: create navigation framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,16 @@ jobs:
         run: |
           chmod +x ./gradlew
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
+        run: |
+          if [ -n "$GOOGLE_SERVICES" ]; then
+            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
+          else
+            echo "::warning::GOOGLE_SERVICES secret not set. google-services.json will not be created."
+          fi
+
       # Check formatting
       - name: KTFmt Check
         run: |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# 🎓 SkillSwap
+
+**SkillSwap** is a peer-to-peer learning marketplace that connects students who want to learn with other students who can teach.  
+
+Our mission is to make learning **affordable, flexible, and community-driven** by leveraging the skills already available within the student community.  
+
+Many students struggle to afford professional tutoring, while others want to earn money or gain experience by teaching what they know.  
+
+With **SkillSwap**:
+- Learners get affordable help in both academics and hobbies.  
+- Tutors earn extra income and experience by sharing their skills.  
+- The student community becomes a self-sustaining support network.  
+
+---
+
+## 🎯 Target Users
+- **Ava**: a first-year student looking for affordable math tutoring.  
+- **Liam**: a third-year student who wants to earn money by offering piano lessons.  
+
+---
+
+## 🚀 Features
+- 🔐 Secure sign-up & login via email or university SSO with **Firebase Authentication**  
+- 👩‍🏫 Role-based profiles: **Learner, Tutor, or Both**  
+- 📍 Location-based search using **GPS** to find and sort nearby tutors on a map  
+- 📝 Booking system for lessons and scheduling  
+- ⭐ Ratings and reviews for tutors  
+- 💾 **Offline mode**: access to profiles, saved tutors, and booked lessons without internet  
+
+---
+
+## 🏗️ Tech Stack
+- **Frontend**: Mobile app (React Native or Flutter)  
+- **Backend**: Google Firebase (Cloud Firestore, Authentication, Cloud Functions)  
+- **Device Features**: GPS/location services, local caching for offline support  
+
+---
+
+## 📡 Offline Mode
+- ✅ Available offline: profile, saved tutors, booked lessons  
+- 🔄 Online required: new tutor listings, updated ratings, personalized recommendations
+
+
+  
+
+## 🔒 Security
+- Accounts managed with **Firebase Authentication**  
+- Role-based permissions (Learner / Tutor)  
+- Data stored securely in **Cloud Firestore** with strict access rules  

--- a/README.md
+++ b/README.md
@@ -40,10 +40,19 @@ With **SkillBridge**:
 - ✅ Available offline: profile, saved tutors, booked lessons  
 - 🔄 Online required: new tutor listings, updated ratings, personalized recommendations
 
-
   
 
 ## 🔒 Security
 - Accounts managed with **Firebase Authentication**  
 - Role-based permissions (Learner / Tutor)  
-- Data stored securely in **Cloud Firestore** with strict access rules  
+- Data stored securely in **Cloud Firestore** with strict access rules
+
+
+## 🎨 Design (Figma)  
+We use **Figma** to create mockups and track design work.  
+
+- 🔗 [SkillSwap Mockup on Figma](https://www.figma.com/design/KLu1v4Q1ahcIgpufrbxQCV/SkillBridge-mockup?node-id=0-1&t=MaZllQ2pNaWYwCoW-1)  
+- ✅ All team members have **edit access**.  
+- 👩‍💻 **Dev Mode** is enabled so developers can inspect styles and assets.  
+- 🌍 File is set to **public view** so course staff can access it.  
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 🎓 SkillSwap
+# 🎓 SkillBridge
 
-**SkillSwap** is a peer-to-peer learning marketplace that connects students who want to learn with other students who can teach.  
+**SkillBridge** is a peer-to-peer learning marketplace that connects students who want to learn with other students who can teach.  
 
 Our mission is to make learning **affordable, flexible, and community-driven** by leveraging the skills already available within the student community.  
 
 Many students struggle to afford professional tutoring, while others want to earn money or gain experience by teaching what they know.  
 
-With **SkillSwap**:
+With **SkillBridge**:
 - Learners get affordable help in both academics and hobbies.  
 - Tutors earn extra income and experience by sharing their skills.  
 - The student community becomes a self-sustaining support network.  

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,12 +93,12 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "gf_android-sample")
-        property("sonar.projectName", "Android-Sample")
-        property("sonar.organization", "gabrielfleischer")
+        property("sonar.projectKey", "SkillBridgeee_SkillBridgeee")
+        property("sonar.projectName", "SkillBridgeee")
+        property("sonar.organization", "SkillBridgeee")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugUnitTest/")
         // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
         property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
         // Paths to JaCoCo XML coverage report files.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,10 @@ dependencies {
 
     // ----------       Robolectric     ------------
     testImplementation(libs.robolectric)
+
+    implementation("androidx.navigation:navigation-compose:2.8.0")
+    implementation("androidx.compose.material3:material3:1.3.0")
+    implementation("androidx.activity:activity-compose:1.9.3")
 }
 
 tasks.withType<Test> {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,7 +93,7 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "skilbridge")
+        property("sonar.projectKey", "SkillBridgeee_SkillBridgeee")
         property("sonar.projectName", "SkillBridgeee")
         property("sonar.organization", "skilbridge")
         property("sonar.host.url", "https://sonarcloud.io")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,9 +93,9 @@ android {
 
 sonar {
     properties {
-        property("sonar.projectKey", "SkillBridgeee_SkillBridgeee")
+        property("sonar.projectKey", "skilbridge")
         property("sonar.projectName", "SkillBridgeee")
-        property("sonar.organization", "SkillBridgeee")
+        property("sonar.organization", "skilbridge")
         property("sonar.host.url", "https://sonarcloud.io")
         // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
         property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugUnitTest/")

--- a/app/src/androidTest/java/com/android/sample/navigation/NavigationTestsWithPlaceHolderScreens.kt
+++ b/app/src/androidTest/java/com/android/sample/navigation/NavigationTestsWithPlaceHolderScreens.kt
@@ -1,0 +1,152 @@
+package com.android.sample.navigation
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.rememberNavController
+import com.android.sample.ui.components.BottomNavBar
+import com.android.sample.ui.components.TopAppBar
+import com.android.sample.ui.navigation.AppNavGraph
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * NavigationTests
+ *
+ * Instrumented UI tests for verifying navigation functionality within the Jetpack Compose
+ * navigation framework.
+ *
+ * These tests:
+ * - Verify that the home screen is displayed by default.
+ * - Verify that tapping bottom navigation items changes the screen.
+ *
+ * NOTE:
+ * - These are instrumentation tests (run on device/emulator).
+ * - Place this file under app/src/androidTest/java.
+ */
+class NavigationTestsWithPlaceHolderScreens {
+
+  // Compose test rule — handles launching composables and simulating user input.
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun app_launches_with_home_screen_displayed() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      AppNavGraph(navController = navController)
+    }
+
+    // Verify the home screen placeholder text is visible
+    composeTestRule.onNodeWithText("🏠 Home Screen Placeholder").assertIsDisplayed()
+  }
+
+  @Test
+  fun clicking_profile_tab_navigates_to_profile_screen() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      Scaffold(bottomBar = { BottomNavBar(navController) }) {
+        AppNavGraph(navController = navController)
+      }
+    }
+
+    // Click on the "Profile" tab in the bottom navigation bar
+    composeTestRule.onNodeWithText("Profile").performClick()
+
+    // Verify the Profile screen placeholder text appears
+    composeTestRule.onNodeWithText("👤 Profile Screen Placeholder").assertIsDisplayed()
+  }
+
+  @Test
+  fun clicking_skills_tab_navigates_to_skills_screen() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      Scaffold(bottomBar = { BottomNavBar(navController) }) {
+        AppNavGraph(navController = navController)
+      }
+    }
+
+    // Click on the "Skills" tab
+    composeTestRule.onNodeWithText("Skills").performClick()
+
+    // Verify the Skills screen placeholder text appears
+    composeTestRule.onNodeWithText("💡 Skills Screen Placeholder").assertIsDisplayed()
+  }
+
+  /** Test that the back button is NOT visible on root-level destinations (Home, Skills, Profile) */
+  @Test
+  fun topBar_backButton_isNotVisible_onRootScreens() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      Scaffold(bottomBar = { BottomNavBar(navController) }) {
+        AppNavGraph(navController = navController)
+      }
+    }
+
+    val backButton = composeTestRule.onAllNodesWithContentDescription("Back")
+
+    // On Home screen (root)
+    composeTestRule.onNodeWithText("🏠 Home Screen Placeholder").assertExists().assertIsDisplayed()
+    backButton.assertCountEquals(0)
+
+    // Navigate to Profile
+    composeTestRule.onNodeWithText("Profile").performClick()
+    composeTestRule.onNodeWithText("👤 Profile Screen Placeholder").assertIsDisplayed()
+    backButton.assertCountEquals(0)
+
+    // Navigate to Skills
+    composeTestRule.onNodeWithText("Skills").performClick()
+    composeTestRule.onNodeWithText("💡 Skills Screen Placeholder").assertIsDisplayed()
+    backButton.assertCountEquals(0)
+  }
+
+  /**
+   * Test that pressing the system back button on a non-root screen navigates back to the previous
+   * screen.
+   *
+   * This test:
+   * - Navigates to Profile screen
+   * - Simulates a system back press
+   * - Verifies we return to the Home screen
+   */
+  @Test
+  fun topBar_backButton_navigatesFromSettingsToHome() {
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      Scaffold(
+          topBar = { TopAppBar(navController) }, bottomBar = { BottomNavBar(navController) }) {
+              paddingValues ->
+            androidx.compose.foundation.layout.Box(modifier = Modifier.padding(paddingValues)) {
+              AppNavGraph(navController = navController)
+            }
+          }
+    }
+
+    // Wait for Compose UI to initialize
+    composeTestRule.waitForIdle()
+
+    // Verify we start on Home
+    composeTestRule.onNodeWithText("🏠 Home Screen Placeholder").assertExists().assertIsDisplayed()
+
+    // Click the Settings tab in the bottom nav
+    composeTestRule.onNodeWithText("Settings").performClick()
+
+    // Verify Settings screen is displayed
+    composeTestRule
+        .onNodeWithText("⚙️ Settings Screen Placeholder")
+        .assertExists()
+        .assertIsDisplayed()
+
+    // Verify TopAppBar back button is visible
+    val backButton = composeTestRule.onNodeWithContentDescription("Back")
+    backButton.assertExists()
+    backButton.assertIsDisplayed()
+
+    // Click the back button
+    backButton.performClick()
+
+    // Verify we are back on Home
+    composeTestRule.onNodeWithText("🏠 Home Screen Placeholder").assertExists().assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/android/sample/MainActivity.kt
+++ b/app/src/main/java/com/android/sample/MainActivity.kt
@@ -3,41 +3,30 @@ package com.android.sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
-import androidx.compose.ui.tooling.preview.Preview
-import com.android.sample.resources.C
-import com.android.sample.ui.theme.SampleAppTheme
+import androidx.navigation.compose.rememberNavController
+import com.android.sample.ui.components.BottomNavBar
+import com.android.sample.ui.components.TopAppBar
+import com.android.sample.ui.navigation.AppNavGraph
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContent {
-      SampleAppTheme {
-        // A surface container using the 'background' color from the theme
-        Surface(
-            modifier = Modifier.fillMaxSize().semantics { testTag = C.Tag.main_screen_container },
-            color = MaterialTheme.colorScheme.background) {
-              Greeting("Android")
-            }
-      }
-    }
+    setContent { MainApp() }
   }
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-  Text(text = "Hello $name!", modifier = modifier.semantics { testTag = C.Tag.greeting })
-}
+fun MainApp() {
+  val navController = rememberNavController()
 
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-  SampleAppTheme { Greeting("Android") }
+  Scaffold(topBar = { TopAppBar(navController) }, bottomBar = { BottomNavBar(navController) }) {
+      paddingValues ->
+    androidx.compose.foundation.layout.Box(modifier = Modifier.padding(paddingValues)) {
+      AppNavGraph(navController = navController)
+    }
+  }
 }

--- a/app/src/main/java/com/android/sample/ui/components/BottomNavBar.kt
+++ b/app/src/main/java/com/android/sample/ui/components/BottomNavBar.kt
@@ -1,0 +1,69 @@
+package com.android.sample.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.android.sample.ui.navigation.NavRoutes
+
+/**
+ * BottomNavBar
+ *
+ * This composable defines the app’s bottom navigation bar. It allows users to switch between key
+ * screens (Home, Skills, Profile, Settings) by tapping icons at the bottom of the screen.
+ *
+ * How it works:
+ * - The NavigationBar is part of Material3 design.
+ * - Each [NavigationBarItem] represents a screen and has: → An icon → A text label → A route to
+ *   navigate to when clicked
+ * - The bar highlights the active route using [selected].
+ * - Navigation is handled by the shared [NavHostController].
+ *
+ * How to add a new tab:
+ * 1. Add a new route constant to [NavRoutes].
+ * 2. Add a new [BottomNavItem] to the `items` list below.
+ * 3. Add a corresponding `composable()` entry to [NavGraph].
+ *
+ * How to remove a tab:
+ * - Simply remove it from the `items` list below.
+ */
+@Composable
+fun BottomNavBar(navController: NavHostController) {
+  val navBackStackEntry by navController.currentBackStackEntryAsState()
+  val currentRoute = navBackStackEntry?.destination?.route
+
+  val items =
+      listOf(
+          BottomNavItem("Home", Icons.Default.Home, NavRoutes.HOME),
+          BottomNavItem("Skills", Icons.Default.Star, NavRoutes.SKILLS),
+          BottomNavItem("Profile", Icons.Default.Person, NavRoutes.PROFILE),
+          BottomNavItem("Settings", Icons.Default.Settings, NavRoutes.SETTINGS))
+
+  NavigationBar {
+    items.forEach { item ->
+      NavigationBarItem(
+          selected = currentRoute == item.route,
+          onClick = {
+            navController.navigate(item.route) {
+              popUpTo(NavRoutes.HOME) { saveState = true }
+              launchSingleTop = true
+              restoreState = true
+            }
+          },
+          icon = { Icon(item.icon, contentDescription = item.label) },
+          label = { Text(item.label) })
+    }
+  }
+}
+
+data class BottomNavItem(
+    val label: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val route: String
+)

--- a/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
+++ b/app/src/main/java/com/android/sample/ui/components/TopAppBar.kt
@@ -1,0 +1,50 @@
+package com.android.sample.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+
+/**
+ * TopBar composable
+ *
+ * Displays a top app bar with:
+ * - The current screen's title
+ * - A back arrow button if the user can navigate back
+ *
+ * @param navController The app's NavController, used to detect back stack state and navigate up.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopAppBar(navController: NavController) {
+  // Observe the current navigation state
+  val navBackStackEntry = navController.currentBackStackEntryAsState()
+  val currentDestination = navBackStackEntry.value?.destination
+
+  // Define the title based on the current route
+  val title =
+      when (currentDestination?.route) {
+        "home" -> "Home"
+        "skills" -> "Skills"
+        "profile" -> "Profile"
+        "settings" -> "Settings"
+        else -> "SkillBridge"
+      }
+
+  // Determine if the back arrow should be visible
+  val canNavigateBack = navController.previousBackStackEntry != null
+
+  TopAppBar(
+      title = { Text(text = title, fontWeight = FontWeight.SemiBold) },
+      navigationIcon = {
+        // Show back arrow only if not on the root (e.g., Home)
+        if (canNavigateBack) {
+          IconButton(onClick = { navController.navigateUp() }) {
+            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+          }
+        }
+      })
+}

--- a/app/src/main/java/com/android/sample/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavGraph.kt
@@ -1,0 +1,42 @@
+package com.android.sample.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.android.sample.ui.screens.HomePlaceholder
+import com.android.sample.ui.screens.ProfilePlaceholder
+import com.android.sample.ui.screens.SettingsPlaceholder
+import com.android.sample.ui.screens.SkillsPlaceholder
+
+/**
+ * AppNavGraph
+ *
+ * This file defines the navigation graph for the app using Jetpack Navigation Compose. It maps
+ * navigation routes (defined in [NavRoutes]) to the composable screens that should be displayed
+ * when the user navigates to that route.
+ *
+ * How it works:
+ * - [NavHost] acts as the navigation container.
+ * - Each `composable()` inside NavHost represents one screen in the app.
+ * - The [navController] is used to navigate between routes.
+ *
+ * Example usage: navController.navigate(NavRoutes.PROFILE)
+ *
+ * To add a new screen:
+ * 1. Create a new composable screen (e.g., MyNewScreen.kt) inside ui/screens/.
+ * 2. Add a new route constant to [NavRoutes] (e.g., const val MY_NEW_SCREEN = "my_new_screen").
+ * 3. Add a new `composable()` entry below with your screen function.
+ * 4. (Optional) Add your route to the bottom navigation bar if needed.
+ *
+ * This makes it easy to add, remove, or rename screens without breaking navigation.
+ */
+@Composable
+fun AppNavGraph(navController: NavHostController) {
+  NavHost(navController = navController, startDestination = NavRoutes.HOME) {
+    composable(NavRoutes.HOME) { HomePlaceholder(navController) }
+    composable(NavRoutes.PROFILE) { ProfilePlaceholder(navController) }
+    composable(NavRoutes.SKILLS) { SkillsPlaceholder(navController) }
+    composable(NavRoutes.SETTINGS) { SettingsPlaceholder(navController) }
+  }
+}

--- a/app/src/main/java/com/android/sample/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/android/sample/ui/navigation/NavRoutes.kt
@@ -1,0 +1,27 @@
+package com.android.sample.ui.navigation
+
+/**
+ * Defines the navigation routes for the application.
+ *
+ * This object centralizes all route constants, providing a single source of truth for navigation.
+ * This makes the navigation system easier to maintain, as all route strings are in one place.
+ *
+ * ## How to use
+ *
+ * ### Adding a new screen:
+ * 1. Add a new `const val` for the screen's route (e.g., `const val NEW_SCREEN = "new_screen"`).
+ * 2. Add the new route to the `NavGraph.kt` file with its corresponding composable.
+ * 3. If the screen should be in the bottom navigation bar, add it to the items list in
+ *    `BottomNavBar.kt`.
+ *
+ * ### Removing a screen:
+ * 1. Remove the `const val` for the screen's route.
+ * 2. Remove the route and its composable from `NavGraph.kt`.
+ * 3. If it was in the bottom navigation bar, remove it from the items list in `BottomNavBar.kt`.
+ */
+object NavRoutes {
+  const val HOME = "home"
+  const val PROFILE = "profile"
+  const val SKILLS = "skills"
+  const val SETTINGS = "settings"
+}

--- a/app/src/main/java/com/android/sample/ui/screens/HomePlaceholder.kt
+++ b/app/src/main/java/com/android/sample/ui/screens/HomePlaceholder.kt
@@ -1,0 +1,10 @@
+package com.android.sample.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+
+@Composable
+fun HomePlaceholder(navController: NavHostController) {
+  Text("🏠 Home Screen Placeholder")
+}

--- a/app/src/main/java/com/android/sample/ui/screens/ProfilePlaceholder.kt
+++ b/app/src/main/java/com/android/sample/ui/screens/ProfilePlaceholder.kt
@@ -1,0 +1,10 @@
+package com.android.sample.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+
+@Composable
+fun ProfilePlaceholder(navController: NavHostController) {
+  Text("👤 Profile Screen Placeholder")
+}

--- a/app/src/main/java/com/android/sample/ui/screens/SettingsPlaceholder.kt
+++ b/app/src/main/java/com/android/sample/ui/screens/SettingsPlaceholder.kt
@@ -1,0 +1,10 @@
+package com.android.sample.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+
+@Composable
+fun SettingsPlaceholder(navController: NavHostController) {
+  Text("⚙️ Settings Screen Placeholder")
+}

--- a/app/src/main/java/com/android/sample/ui/screens/SkillsPlaceholder.kt
+++ b/app/src/main/java/com/android/sample/ui/screens/SkillsPlaceholder.kt
@@ -1,0 +1,10 @@
+package com.android.sample.ui.screens
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+
+@Composable
+fun SkillsPlaceholder(navController: NavHostController) {
+  Text("💡 Skills Screen Placeholder")
+}


### PR DESCRIPTION
### **Summary**

This PR implements the initial navigation framework for the SkillBridge app using Jetpack Compose and Navigation Compose. It includes:

- A flexible AppNavGraph that defines all current routes (Home, Skills, Profile, Settings).
- A BottomNavBar to switch between root screens.
- A TopAppBar with a conditional back button that appears when navigating to non-root destinations.
- Unit and instrumentation tests for navigation behavior.

### Changes Made

1. **Navigation Graph**

-   AppNavGraph.kt defines the NavHost with all current screens.
-   Routes are centralized in NavRoutes.kt for easy maintenance.
-   Screens are mapped to composables: HomePlaceholder, SkillsPlaceholder, ProfilePlaceholder, SettingsPlaceholder.

2. **UI Components**

-   BottomNavBar.kt implements the bottom navigation bar with highlight for active tab.
-   TopAppBar.kt displays a dynamic back button if a previous back stack entry exists.

3. **MainActivity & Scaffold**

- MainApp() sets up the Scaffold with TopAppBar and BottomNavBar.
- AppNavGraph is used inside the content area to handle navigation.

4. **Navigation Tests**

- Tests ensure the app launches on Home by default.
- Clicking bottom nav items navigates correctly to other screens.
- TopAppBar back button:

  - Does not appear on root screens.
  - Appears on deeper screens and navigates back to the previous screen.
- All tests use createComposeRule() and simulate navigation via UI interactions; no direct activity access is required.

### Next Steps / Notes

- As the app grows, additional screens can be added to NavRoutes and AppNavGraph without breaking existing navigation.
- Back stack behavior may need further refinement when adding nested or modal screens.
- Optional: consider separating “SettingsDetails” or subpages for more realistic back navigation testing.

Made by AI: tests, comments. Also asked it for the best way to go about creating the framework asking fro pointers as I went. Asked it to check the code after it was written to find any errors.